### PR TITLE
Metapaymaster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/
 # Intellij
 .idea/
 
+/records/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/Vectorized/solady

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/openzeppelin-contracts-upgradeable"]
+	path = lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,7 @@ optimizer_runs = 999999
 solc_version = "0.8.20"
 remappings = [
     '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts',
+    '@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts',
     "@account-abstraction/=lib/account-abstraction/contracts",
 ]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ solc_version = "0.8.20"
 remappings = [
     '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts',
     '@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts',
-    "@account-abstraction/=lib/account-abstraction/contracts",
+    '@account-abstraction/=lib/account-abstraction/contracts',
+    '@solady/=lib/solady/src',
 ]
 

--- a/script/DeployMetaPaymaster.s.sol
+++ b/script/DeployMetaPaymaster.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
-import "../src/MetaPaymaster.sol";
+import "../src/meta/MetaPaymaster.sol";
 import "@account-abstraction/interfaces/IEntryPoint.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";

--- a/script/DeployMetaPaymaster.s.sol
+++ b/script/DeployMetaPaymaster.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../src/MetaPaymaster.sol";
+import "@account-abstraction/interfaces/IEntryPoint.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+// This script deploys a Paymaster
+contract DeployPaymaster is Script {
+    address entryPoint = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
+
+    function run() public {
+        vm.broadcast();
+        MetaPaymaster paymaster = new MetaPaymaster();
+        vm.broadcast();
+        ProxyAdmin admin = new ProxyAdmin();
+        bytes memory data = abi.encodeWithSignature("initialize(address,address)", tx.origin, IEntryPoint(entryPoint));
+        vm.broadcast();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(paymaster), address(admin), data);
+        require(address(MetaPaymaster(payable(proxy)).entryPoint()) == entryPoint);
+        require(MetaPaymaster(payable(proxy)).owner() == tx.origin);
+        require(admin.owner() == tx.origin);
+    }
+}

--- a/script/DeployMetaPaymaster.s.sol
+++ b/script/DeployMetaPaymaster.s.sol
@@ -7,7 +7,7 @@ import "@account-abstraction/interfaces/IEntryPoint.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-// This script deploys a Paymaster
+// This script deploys a Paymaster and sets the deployer as the owner address
 contract DeployPaymaster is Script {
     address entryPoint = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
 

--- a/script/SetMetaPaymasterBalance.s.sol
+++ b/script/SetMetaPaymasterBalance.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../src/meta/MetaPaymaster.sol";
+
+contract SetMetaPaymasterBalance is Script {
+    MetaPaymaster metaPaymaster = MetaPaymaster(payable(0x75B9328BB753144705b77b215E304eC7ef45235C));
+
+    function run(address account, uint256 amount) public {
+        vm.broadcast();
+        metaPaymaster.setBalance(account, amount);
+        require(metaPaymaster.balanceOf(account) == amount);
+    }
+}

--- a/src/MetaPaymaster.sol
+++ b/src/MetaPaymaster.sol
@@ -8,9 +8,19 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@solady/utils/SafeTransferLib.sol";
 
+/**
+ * A meta-paymaster that deposits funds to the 4337 entryPoint on behalf
+ * of allowlisted paymasters, just-in-time per userOperation.
+ */
 contract MetaPaymaster is OwnableUpgradeable {
     IEntryPoint public entryPoint;
+
+    // Funds available to each individual paymaster
     mapping(address => uint256) public balanceOf;
+
+    // Total funds allocated to all paymasters (sum of all balanceOf).
+    // Tracked separately from the contract's balance, since balances
+    // can be undercollateralized.
     uint256 public total;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -18,15 +28,34 @@ contract MetaPaymaster is OwnableUpgradeable {
         _disableInitializers();
     }
 
-    function initialize(address owner, IEntryPoint _entryPoint) public initializer {
-        __Ownable_init(owner);
+    /**
+     * @notice Initializes the contract.
+     * @param _owner The owner of the contract.
+     * @param _entryPoint The 4337 EntryPoint contract.
+     */
+    function initialize(address _owner, IEntryPoint _entryPoint) public initializer {
+        __Ownable_init(_owner);
         entryPoint = _entryPoint;
     }
 
-    function willFund(address msgSender, uint256 actualGasCost) public view returns (bool) {
-        return balanceOf[msgSender] >= actualGasCost && address(this).balance >= actualGasCost;
+    /**
+     * @notice Helper function to check if this contract will fund a userOperation.
+     * @param account The address that will call `fund` (usually the paymaster).
+     * @param actualGasCost The actual gas cost of the userOp, including postOp overhead.
+     * @return True if this contract will fund the given gas cost.
+     */
+    function willFund(address account, uint256 actualGasCost) public view returns (bool) {
+        return balanceOf[account] >= actualGasCost && address(this).balance >= actualGasCost;
     }
 
+    /**
+     * @notice Deposits funds to the 4337 entryPoint on behalf of a paymaster.
+     * @dev `actualGasCost` can be calculated using the formula:
+     * `postOp.actualGasCost + postOpOverhead * gasPrice`, where `postOpOverhead`
+     * is a constant representing the gas usage of the postOp function.
+     * @param paymaster The paymaster to fund (`address(this)` when called from the paymaster).
+     * @param actualGasCost The actual gas cost of the userOp, including postOp overhead.
+     */
     function fund(address paymaster, uint256 actualGasCost) external {
         require(balanceOf[msg.sender] >= actualGasCost);
         total -= actualGasCost;
@@ -34,11 +63,20 @@ contract MetaPaymaster is OwnableUpgradeable {
         entryPoint.depositTo{value: actualGasCost}(paymaster);
     }
 
+    /**
+     * @notice Helper to deposit + associate funds with a particular paymaster.
+     * @param account The address to associate the funds with.
+     */
     function depositTo(address account) public payable {
         total += msg.value;
         balanceOf[account] += msg.value;
     }
 
+    /**
+     * @notice Sets the balance of a particular account / paymaster.
+     * @param account The account to set the balance of.
+     * @param amount The amount to set the balance to.
+     */
     function setBalance(address account, uint256 amount) public onlyOwner {
         if (amount > balanceOf[account]) {
             total += amount - balanceOf[account];
@@ -48,6 +86,11 @@ contract MetaPaymaster is OwnableUpgradeable {
         balanceOf[account] = amount;
     }
 
+    /**
+     * @notice Withdraws funds from the contract.
+     * @param withdrawAddress The address to withdraw to.
+     * @param withdrawAmount The amount to withdraw.
+     */
     function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) public onlyOwner {
         SafeTransferLib.safeTransferETH(withdrawAddress, withdrawAmount);
     }

--- a/src/MetaPaymaster.sol
+++ b/src/MetaPaymaster.sol
@@ -23,8 +23,8 @@ contract MetaPaymaster is OwnableUpgradeable {
         entryPoint = _entryPoint;
     }
 
-    function willFund(uint256 actualGasCost) public view returns (bool) {
-        return balanceOf[msg.sender] >= actualGasCost && address(this).balance >= actualGasCost;
+    function willFund(address msgSender, uint256 actualGasCost) public view returns (bool) {
+        return balanceOf[msgSender] >= actualGasCost && address(this).balance >= actualGasCost;
     }
 
     function fund(address paymaster, uint256 actualGasCost) external {

--- a/src/MetaPaymaster.sol
+++ b/src/MetaPaymaster.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+/* solhint-disable reason-string */
+
+import "@account-abstraction/interfaces/IEntryPoint.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+contract MetaPaymaster is OwnableUpgradeable {
+    IEntryPoint public entryPoint;
+    mapping(address => uint256) public balances;
+    uint256 public total;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner, IEntryPoint _entryPoint) public initializer {
+        __Ownable_init(owner);
+        entryPoint = _entryPoint;
+    }
+
+    function fund(uint256 actualGasCost) external returns (bool) {
+        if (address(this).balance < actualGasCost) {
+            return false;
+        }
+        if (balances[msg.sender] < actualGasCost) {
+            return false;
+        }
+        total -= actualGasCost;
+        balances[msg.sender] -= actualGasCost;
+        entryPoint.depositTo{value: actualGasCost}(msg.sender);
+        return true;
+    }
+
+    function balance() public view returns (uint256) {
+        return balances[msg.sender];
+    }
+
+    function balanceOf(address account) public view returns (uint256) {
+        return balances[account];
+    }
+
+    function depositTo(address account) public payable {
+        total += msg.value;
+        balances[account] += msg.value;
+    }
+
+    function setBalance(address account, uint256 amount) public onlyOwner {
+        total += amount - balances[account];
+        balances[account] = amount;
+    }
+
+    function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) public onlyOwner {
+        (bool success,) = withdrawAddress.call{value : withdrawAmount}("");
+        require(success, "failed to withdraw");
+    }
+
+    receive() external payable {}
+}

--- a/src/MetaPaymaster.sol
+++ b/src/MetaPaymaster.sol
@@ -40,7 +40,11 @@ contract MetaPaymaster is OwnableUpgradeable {
     }
 
     function setBalance(address account, uint256 amount) public onlyOwner {
-        total += amount - balanceOf[account];
+        if (amount > balanceOf[account]) {
+            total += amount - balanceOf[account];
+        } else {
+            total -= balanceOf[account] - amount;
+        }
         balanceOf[account] = amount;
     }
 

--- a/src/MeteePaymaster.sol
+++ b/src/MeteePaymaster.sol
@@ -85,7 +85,7 @@ contract MeteePaymaster is BasePaymaster {
 
     function _postOp(PostOpMode mode, bytes calldata /*context*/, uint256 actualGasCost) internal override {
         if (mode != PostOpMode.postOpReverted) {
-            metaPaymaster.fund(actualGasCost + 3453969250695);
+            metaPaymaster.fund(address(this), actualGasCost + 3453969250695);
         }
     }
 

--- a/src/MeteePaymaster.sol
+++ b/src/MeteePaymaster.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+/* solhint-disable reason-string */
+
+import "@account-abstraction/core/BasePaymaster.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "./MetaPaymaster.sol";
+
+/**
+ * A paymaster that uses external service to decide whether to pay for the UserOp.
+ * The paymaster trusts an external signer to sign the transaction.
+ * The calling user must pass the UserOp to that external signer first, which performs
+ * whatever off-chain verification before signing the UserOp.
+ * Note that this signature is NOT a replacement for the account-specific signature:
+ * - the paymaster checks a signature to agree to PAY for GAS.
+ * - the account checks a signature to prove identity and account ownership.
+ */
+contract MeteePaymaster is BasePaymaster {
+    using UserOperationLib for UserOperation;
+
+    address public immutable verifyingSigner;
+    MetaPaymaster public immutable metaPaymaster;
+
+    uint256 private constant VALID_TIMESTAMP_OFFSET = 20;
+    uint256 private constant SIGNATURE_OFFSET = VALID_TIMESTAMP_OFFSET + 64;
+
+    constructor(IEntryPoint _entryPoint, address _verifyingSigner, MetaPaymaster _metaPaymaster) BasePaymaster(_entryPoint) Ownable() {
+        verifyingSigner = _verifyingSigner;
+        metaPaymaster = _metaPaymaster;
+    }
+
+    /**
+     * return the hash we're going to sign off-chain (and validate on-chain)
+     * this method is called by the off-chain service, to sign the request.
+     * it is called on-chain from the validatePaymasterUserOp, to validate the signature.
+     * note that this signature covers all fields of the UserOperation, except the "paymasterAndData",
+     * which will carry the signature itself.
+     */
+    function getHash(UserOperation calldata userOp, uint48 validUntil, uint48 validAfter)
+    public view returns (bytes32) {
+        // can't use userOp.hash(), since it contains also the paymasterAndData itself.
+        return keccak256(
+            abi.encode(
+                userOp.getSender(),
+                userOp.nonce,
+                calldataKeccak(userOp.initCode),
+                calldataKeccak(userOp.callData),
+                userOp.callGasLimit,
+                userOp.verificationGasLimit,
+                userOp.preVerificationGas,
+                userOp.maxFeePerGas,
+                userOp.maxPriorityFeePerGas,
+                block.chainid,
+                address(this),
+                validUntil,
+                validAfter
+            )
+        );
+    }
+
+    /**
+     * verify our external signer signed this request.
+     * the "paymasterAndData" is expected to be the paymaster and a signature over the entire request params
+     * paymasterAndData[:20] : address(this)
+     * paymasterAndData[20:84] : abi.encode(validUntil, validAfter)
+     * paymasterAndData[84:] : signature
+     */
+    function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32 /*userOpHash*/, uint256 /*requiredPreFund*/)
+    internal override view returns (bytes memory context, uint256 validationData) {
+        (uint48 validUntil, uint48 validAfter, bytes calldata signature) = parsePaymasterAndData(userOp.paymasterAndData);
+        // Only support 65-byte signatures, to avoid potential replay attacks.
+        require(signature.length == 65, "Paymaster: invalid signature length in paymasterAndData");
+        bytes32 hash = ECDSA.toEthSignedMessageHash(getHash(userOp, validUntil, validAfter));
+
+        // don't revert on signature failure: return SIG_VALIDATION_FAILED
+        if (verifyingSigner != ECDSA.recover(hash, signature)) {
+            return ("", _packValidationData(true, validUntil, validAfter));
+        }
+
+        // no need for other on-chain validation: entire UserOp should have been checked
+        // by the external service prior to signing it.
+        return (" ", _packValidationData(false, validUntil, validAfter));
+    }
+
+    function _postOp(PostOpMode mode, bytes calldata /*context*/, uint256 actualGasCost) internal override {
+        if (mode != PostOpMode.postOpReverted) {
+            metaPaymaster.fund(actualGasCost + 3453969250695);
+        }
+    }
+
+    function parsePaymasterAndData(bytes calldata paymasterAndData)
+    internal pure returns(uint48 validUntil, uint48 validAfter, bytes calldata signature) {
+        (validUntil, validAfter) = abi.decode(paymasterAndData[VALID_TIMESTAMP_OFFSET:SIGNATURE_OFFSET],(uint48, uint48));
+        signature = paymasterAndData[SIGNATURE_OFFSET:];
+    }
+
+    receive() external payable {
+        // use address(this).balance rather than msg.value in case of force-send
+        (bool callSuccess, ) = payable(address(entryPoint)).call{value: address(this).balance}("");
+        require(callSuccess, "Deposit failed");
+    }
+}

--- a/src/meta/BaseFundedPaymaster.sol
+++ b/src/meta/BaseFundedPaymaster.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "@account-abstraction/core/BasePaymaster.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "./MetaPaymaster.sol";
+
+/**
+ * Abstract paymaster that uses the `MetaPaymaster` for funding the
+ * gas costs of each userOp by calling the `fund` method in `postOp`.
+ */
+abstract contract BaseFundedPaymaster is BasePaymaster {
+    MetaPaymaster public immutable metaPaymaster;
+
+    uint256 private constant POST_OP_OVERHEAD = 34982;
+
+    constructor(IEntryPoint _entryPoint, MetaPaymaster _metaPaymaster) BasePaymaster(_entryPoint) Ownable() {
+        metaPaymaster = _metaPaymaster;
+    }
+
+    function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 requiredPreFund)
+    internal override returns (bytes memory context, uint256 validationData) {
+        validationData = __validatePaymasterUserOp(userOp, userOpHash, requiredPreFund);
+        return (abi.encode(userOp.maxFeePerGas, userOp.maxPriorityFeePerGas), validationData);
+    }
+
+    function __validatePaymasterUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 maxCost)
+    internal virtual returns (uint256 validationData);
+
+    function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal override {
+        if (mode != PostOpMode.postOpReverted) {
+            (uint256 maxFeePerGas, uint256 maxPriorityFeePerGas) = abi.decode(context, (uint256, uint256));
+            uint256 gasPrice = min(maxFeePerGas, maxPriorityFeePerGas + block.basefee);
+            metaPaymaster.fund(address(this), actualGasCost + POST_OP_OVERHEAD*gasPrice);
+        }
+    }
+
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+}

--- a/src/meta/FundedPaymaster.sol
+++ b/src/meta/FundedPaymaster.sol
@@ -1,34 +1,27 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.20;
 
-/* solhint-disable reason-string */
-
 import "@account-abstraction/core/BasePaymaster.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "./MetaPaymaster.sol";
+import "./BaseFundedPaymaster.sol";
 
 /**
  * A paymaster that uses external service to decide whether to pay for the UserOp.
  * The paymaster trusts an external signer to sign the transaction.
  * The calling user must pass the UserOp to that external signer first, which performs
- * whatever off-chain verification before signing the UserOp.
- * Note that this signature is NOT a replacement for the account-specific signature:
- * - the paymaster checks a signature to agree to PAY for GAS.
- * - the account checks a signature to prove identity and account ownership.
+ * whatever off-chain verification before signing the UserOp.\
+ * Actual funding is provided by a meta-paymaster.
  */
-contract MeteePaymaster is BasePaymaster {
+contract FundedPaymaster is BaseFundedPaymaster {
     using UserOperationLib for UserOperation;
 
     address public immutable verifyingSigner;
-    MetaPaymaster public immutable metaPaymaster;
 
     uint256 private constant VALID_TIMESTAMP_OFFSET = 20;
     uint256 private constant SIGNATURE_OFFSET = VALID_TIMESTAMP_OFFSET + 64;
-    uint256 private constant POST_OP_OVERHEAD = 34982;
 
-    constructor(IEntryPoint _entryPoint, address _verifyingSigner, MetaPaymaster _metaPaymaster) BasePaymaster(_entryPoint) Ownable() {
+    constructor(IEntryPoint _entryPoint, MetaPaymaster _metaPaymaster, address _verifyingSigner) BaseFundedPaymaster(_entryPoint, _metaPaymaster) {
         verifyingSigner = _verifyingSigner;
-        metaPaymaster = _metaPaymaster;
     }
 
     /**
@@ -67,8 +60,8 @@ contract MeteePaymaster is BasePaymaster {
      * paymasterAndData[20:84] : abi.encode(validUntil, validAfter)
      * paymasterAndData[84:] : signature
      */
-    function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32 /*userOpHash*/, uint256 /*requiredPreFund*/)
-    internal override view returns (bytes memory context, uint256 validationData) {
+    function __validatePaymasterUserOp(UserOperation calldata userOp, bytes32 /*userOpHash*/, uint256 /*requiredPreFund*/)
+    internal override view returns (uint256) {
         (uint48 validUntil, uint48 validAfter, bytes calldata signature) = parsePaymasterAndData(userOp.paymasterAndData);
         // Only support 65-byte signatures, to avoid potential replay attacks.
         require(signature.length == 65, "Paymaster: invalid signature length in paymasterAndData");
@@ -76,24 +69,12 @@ contract MeteePaymaster is BasePaymaster {
 
         // don't revert on signature failure: return SIG_VALIDATION_FAILED
         if (verifyingSigner != ECDSA.recover(hash, signature)) {
-            return ("", _packValidationData(true, validUntil, validAfter));
+            return _packValidationData(true, validUntil, validAfter);
         }
 
         // no need for other on-chain validation: entire UserOp should have been checked
         // by the external service prior to signing it.
-        return (abi.encode(userOp.maxFeePerGas, userOp.maxPriorityFeePerGas), _packValidationData(false, validUntil, validAfter));
-    }
-
-    function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal override {
-        if (mode != PostOpMode.postOpReverted) {
-            (uint256 maxFeePerGas, uint256 maxPriorityFeePerGas) = abi.decode(context, (uint256, uint256));
-            uint256 gasPrice = min(maxFeePerGas, maxPriorityFeePerGas + block.basefee);
-            metaPaymaster.fund(address(this), actualGasCost + POST_OP_OVERHEAD*gasPrice);
-        }
-    }
-
-    function min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a < b ? a : b;
+        return _packValidationData(false, validUntil, validAfter);
     }
 
     function parsePaymasterAndData(bytes calldata paymasterAndData)

--- a/src/meta/MetaPaymaster.sol
+++ b/src/meta/MetaPaymaster.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import "@account-abstraction/interfaces/IEntryPoint.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@solady/utils/SafeTransferLib.sol";
 

--- a/src/meta/MetaPaymaster.sol
+++ b/src/meta/MetaPaymaster.sol
@@ -1,7 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
-
-/* solhint-disable reason-string */
 
 import "@account-abstraction/interfaces/IEntryPoint.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";


### PR DESCRIPTION
Usage of the metapaymaster from a paymaster:
```solidity
contract Paymaster is BasePaymaster {
    MetaPaymaster public immutable metaPaymaster;

    uint256 private constant POST_OP_OVERHEAD = 34982;

    function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 requiredPreFund)
    internal override returns (bytes memory context, uint256 validationData) {
        // TODO: validate userOp here
        return (abi.encode(userOp.maxFeePerGas, userOp.maxPriorityFeePerGas), validationData);
    }

    function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal override {
        if (mode != PostOpMode.postOpReverted) {
            (uint256 maxFeePerGas, uint256 maxPriorityFeePerGas) = abi.decode(context, (uint256, uint256));
            uint256 gasPrice = min(maxFeePerGas, maxPriorityFeePerGas + block.basefee);
            metaPaymaster.fund(address(this), actualGasCost + POST_OP_OVERHEAD*gasPrice);
        }
    }

    function min(uint256 a, uint256 b) internal pure returns (uint256) {
        return a < b ? a : b;
    }
}
```

An abstract base contract has been provided that implements much of this logic: `BaseFundedPaymaster`.

Deployed metapaymaster addresses:
 - https://goerli.basescan.org/address/0xe4d2db385a32C7A61E11e921A6238afA2D3EB2f1
 - https://basescan.org/address/0x75b9328bb753144705b77b215e304ec7ef45235c