### PR TITLE
test: added a test to ensure valid ownership always remains transferable

### DIFF
--- a/src/Paymaster.sol
+++ b/src/Paymaster.sol
@@ -94,9 +94,8 @@ contract Paymaster is BasePaymaster {
     }
 
     function transferOwnership(address newOwner) public override onlyOwner {
-        require(newOwner != address(0), "Paymaster: owner cannot be address(0)");
         require(newOwner != verifyingSigner, "Paymaster: owner cannot be the verifyingSigner");
-        _transferOwnership(newOwner);
+        super.transferOwnership(newOwner);
     }
 
     receive() external payable {

--- a/test/Paymaster.t.sol
+++ b/test/Paymaster.t.sol
@@ -61,6 +61,12 @@ contract PaymasterTest is Test {
         paymaster.transferOwnership(PAYMASTER_SIGNER);
     }
 
+    function test_transferOwnershipToValidAddress() public {
+        address newOwner = address(0x1234567890123456789012345678901234567890);
+        paymaster.transferOwnership(newOwner);
+        assertEq(paymaster.owner(), newOwner);
+    }
+
     function test_getHash() public {
         UserOperation memory userOp = createUserOp();
         userOp.sender = ACCOUNT_OWNER;

--- a/test/Paymaster.t.sol
+++ b/test/Paymaster.t.sol
@@ -80,7 +80,7 @@ contract PaymasterTest is Test {
         UserOperation memory userOp = createUserOp();
         signUserOp(userOp);
 
-        vm.expectRevert(createEncodedValidationResult(false, 52981));
+        vm.expectRevert(createEncodedValidationResult(false, 53025));
         entrypoint.simulateValidation(userOp);
     }
 
@@ -90,7 +90,7 @@ contract PaymasterTest is Test {
         userOp.paymasterAndData = abi.encodePacked(address(paymaster), abi.encode(MOCK_VALID_UNTIL, MOCK_VALID_AFTER), r, s, v);
         signUserOp(userOp);
 
-        vm.expectRevert(createEncodedValidationResult(true, 52991));
+        vm.expectRevert(createEncodedValidationResult(true, 53035));
         entrypoint.simulateValidation(userOp);
     }
 

--- a/test/Paymaster.t.sol
+++ b/test/Paymaster.t.sol
@@ -52,7 +52,7 @@ contract PaymasterTest is Test {
     }
 
     function test_zeroAddressTransferOwnership() public {
-        vm.expectRevert("Paymaster: owner cannot be address(0)");
+        vm.expectRevert("Ownable: new owner is the zero address");
         paymaster.transferOwnership(address(0));
     }
 
@@ -80,7 +80,7 @@ contract PaymasterTest is Test {
         UserOperation memory userOp = createUserOp();
         signUserOp(userOp);
 
-        vm.expectRevert(createEncodedValidationResult(false, 53025));
+        vm.expectRevert(createEncodedValidationResult(false, 52981));
         entrypoint.simulateValidation(userOp);
     }
 
@@ -90,7 +90,7 @@ contract PaymasterTest is Test {
         userOp.paymasterAndData = abi.encodePacked(address(paymaster), abi.encode(MOCK_VALID_UNTIL, MOCK_VALID_AFTER), r, s, v);
         signUserOp(userOp);
 
-        vm.expectRevert(createEncodedValidationResult(true, 53035));
+        vm.expectRevert(createEncodedValidationResult(true, 52991));
         entrypoint.simulateValidation(userOp);
     }
 


### PR DESCRIPTION
## Issue
The Paymaster contract's `transferOwnership` function currently implements custom zero-address validation and directly calls the internal `_transferOwnership()` method, bypassing OpenZeppelin's standard validation flow. This results in non-standard error messages (`"Paymaster: owner cannot be address(0)"` instead of the conventional `"Ownable: new owner is the zero address"`), and unnecessary code duplication.

## Solution
Refactor to use `super.transferOwnership(newOwner)` instead of directly calling `_transferOwnership(newOwner)`, which leverages OpenZeppelin's built-in zero-address validation while preserving the custom check that prevents the verifying signer from becoming owner. 
